### PR TITLE
Exclude 3rdparty folder from install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,7 +241,9 @@ install(
 install(
     DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/entityx/
     DESTINATION ${include_install_dir}/entityx
-    FILES_MATCHING PATTERN "*.h"
+    FILES_MATCHING 
+    PATTERN "*.h"
+    PATTERN "entityx/3rdparty*" EXCLUDE
 )
 
 install(


### PR DESCRIPTION
@ruslo Previous hunterization still installed the 3rdparty header for SimpleSignal even though it is unused. Fixed with an `EXCLUDE` rule.